### PR TITLE
Initial optimizations

### DIFF
--- a/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
+++ b/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
@@ -105,6 +105,8 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
             useTriggers = false,
         };
 
+        ProjectileManager projectileManager = ProjectileManager.Instance;
+
         for (int i = 0; i < Projectiles.Nodes.Length; i++)
         {
             if (Projectiles.Nodes[i].Active)
@@ -138,7 +140,7 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
                             Projectiles.Nodes[i].Item.Position = RaycastHitBuffer[0].centroid + travelDelta;
                             Projectiles.Nodes[i].Item.Color = Color.Evaluate(1 - Projectiles.Nodes[i].Item.TimeToLive / TimeToLive);
 
-                            ProjectileManager.Instance.UpdateBufferData(ActiveProjectileCount, ProjectileType, Projectiles.Nodes[i].Item);
+                            projectileManager.UpdateBufferData(ActiveProjectileCount, ProjectileType, Projectiles.Nodes[i].Item);
 
                             ActiveProjectileCount++;
                         }
@@ -154,7 +156,7 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
                         Projectiles.Nodes[i].Item.Position += Projectiles.Nodes[i].Item.Velocity * tick;
                         Projectiles.Nodes[i].Item.Color = Color.Evaluate(1 - Projectiles.Nodes[i].Item.TimeToLive / TimeToLive);
 
-                        ProjectileManager.Instance.UpdateBufferData(ActiveProjectileCount, ProjectileType, Projectiles.Nodes[i].Item);
+                        projectileManager.UpdateBufferData(ActiveProjectileCount, ProjectileType, Projectiles.Nodes[i].Item);
 
                         ActiveProjectileCount++;
                     }

--- a/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
+++ b/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
@@ -120,11 +120,11 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
                     Projectiles.Nodes[i].Item.Velocity *= (1 + Projectiles.Nodes[i].Item.Acceleration * tick);
 
                     // calculate where projectile will be at the end of this frame
-                    Vector2 travelDelta = Projectiles.Nodes[i].Item.Velocity * tick; // TODO rename to deltaPosition
-                    float distance = travelDelta.magnitude;
+                    Vector2 deltaPosition = Projectiles.Nodes[i].Item.Velocity * tick;
+                    float distance = deltaPosition.magnitude;
 
                     // Raycast towards where projectile is moving
-                    if (Physics2D.Raycast(Projectiles.Nodes[i].Item.Position, travelDelta, contactFilter, RaycastHitBuffer, distance) > 0)
+                    if (Physics2D.Raycast(Projectiles.Nodes[i].Item.Position, deltaPosition, contactFilter, RaycastHitBuffer, distance) > 0)
                     {
                         // Put whatever hit code you want here such as damage events
 
@@ -135,9 +135,9 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
                             Projectiles.Nodes[i].Item.Velocity = Vector2.Reflect(Projectiles.Nodes[i].Item.Velocity, RaycastHitBuffer[0].normal);
                             // what fraction of the distance do we still have to move this frame?
                             float leakedFraction = 1f - RaycastHitBuffer[0].distance / distance;
-                            travelDelta = Projectiles.Nodes[i].Item.Velocity * tick * leakedFraction;
+                            deltaPosition = Projectiles.Nodes[i].Item.Velocity * tick * leakedFraction;
 
-                            Projectiles.Nodes[i].Item.Position = RaycastHitBuffer[0].centroid + travelDelta;
+                            Projectiles.Nodes[i].Item.Position = RaycastHitBuffer[0].centroid + deltaPosition;
                             Projectiles.Nodes[i].Item.Color = Color.Evaluate(1 - Projectiles.Nodes[i].Item.TimeToLive / TimeToLive);
 
                             projectileManager.UpdateBufferData(ActiveProjectileCount, ProjectileType, Projectiles.Nodes[i].Item);
@@ -153,7 +153,7 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
                     else
                     {
                         // No collision - move projectile
-                        Projectiles.Nodes[i].Item.Position += Projectiles.Nodes[i].Item.Velocity * tick;
+                        Projectiles.Nodes[i].Item.Position += deltaPosition;
                         Projectiles.Nodes[i].Item.Color = Color.Evaluate(1 - Projectiles.Nodes[i].Item.TimeToLive / TimeToLive);
 
                         projectileManager.UpdateBufferData(ActiveProjectileCount, ProjectileType, Projectiles.Nodes[i].Item);

--- a/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
+++ b/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
@@ -99,6 +99,12 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
     {
         ActiveProjectileCount = 0;
 
+        ContactFilter2D contactFilter = new ContactFilter2D
+        {
+            layerMask = LayerMask,
+            useTriggers = false,
+        };
+
         for (int i = 0; i < Projectiles.Nodes.Length; i++)
         {
             if (Projectiles.Nodes[i].Active)
@@ -112,11 +118,11 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
                     Projectiles.Nodes[i].Item.Velocity *= (1 + Projectiles.Nodes[i].Item.Acceleration * tick);
 
                     // calculate where projectile will be at the end of this frame
-                    Vector2 endPoint = Projectiles.Nodes[i].Item.Position + Projectiles.Nodes[i].Item.Velocity * tick;
-                    float distance = (endPoint - Projectiles.Nodes[i].Item.Position).magnitude;
+                    Vector2 travelDelta = Projectiles.Nodes[i].Item.Velocity * tick; // TODO rename to deltaPosition
+                    float distance = travelDelta.magnitude;
 
                     // Raycast towards where projectile is moving
-                    if (Physics2D.RaycastNonAlloc(Projectiles.Nodes[i].Item.Position, Projectiles.Nodes[i].Item.Velocity.normalized, RaycastHitBuffer, distance, LayerMask) > 0)
+                    if (Physics2D.Raycast(Projectiles.Nodes[i].Item.Position, travelDelta, contactFilter, RaycastHitBuffer, distance) > 0)
                     {
                         // Put whatever hit code you want here such as damage events
 

--- a/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
+++ b/Assets/Scripts/Emitters/ProjectileEmitterBase.cs
@@ -131,8 +131,11 @@ public abstract class ProjectileEmitterBase : MonoBehaviour
                         {
                             // rudementary bounce -- will work well on static surfaces
                             Projectiles.Nodes[i].Item.Velocity = Vector2.Reflect(Projectiles.Nodes[i].Item.Velocity, RaycastHitBuffer[0].normal);
+                            // what fraction of the distance do we still have to move this frame?
+                            float leakedFraction = 1f - RaycastHitBuffer[0].distance / distance;
+                            travelDelta = Projectiles.Nodes[i].Item.Velocity * tick * leakedFraction;
 
-                            Projectiles.Nodes[i].Item.Position += Projectiles.Nodes[i].Item.Velocity * tick;
+                            Projectiles.Nodes[i].Item.Position = RaycastHitBuffer[0].centroid + travelDelta;
                             Projectiles.Nodes[i].Item.Color = Color.Evaluate(1 - Projectiles.Nodes[i].Item.TimeToLive / TimeToLive);
 
                             ProjectileManager.Instance.UpdateBufferData(ActiveProjectileCount, ProjectileType, Projectiles.Nodes[i].Item);

--- a/Assets/Scripts/ProjectileManager.cs
+++ b/Assets/Scripts/ProjectileManager.cs
@@ -12,6 +12,10 @@ public class ProjectileManager : MonoBehaviour
     // Each projectile type has its own material, therefore, own IndirectRenderer
     private Dictionary<int, IndirectRenderer> IndirectRenderers;
 
+    // Cache the last accessed IndirectRenderer to reduce the Dict lookup for batches
+    private int LastAccessedProjectileTypeIndex = -1;
+    private IndirectRenderer LastAccessedRenderer;
+
     // Counters to keep track of Projectile Group information
     private Dictionary<int, ProjectileTypeCounters> ProjectileTypeCounters;
 
@@ -119,8 +123,14 @@ public class ProjectileManager : MonoBehaviour
 
     public void UpdateBufferData(int index, ProjectileType projectileType, ProjectileData data)
     {
-        IndirectRenderers[projectileType.Index].UpdateBufferData(ProjectileTypes[projectileType.Index].BufferIndex, data);
-        ProjectileTypes[projectileType.Index].BufferIndex++;
+        if (projectileType.Index != LastAccessedProjectileTypeIndex)
+        {
+            LastAccessedProjectileTypeIndex = projectileType.Index;
+            LastAccessedRenderer = IndirectRenderers[LastAccessedProjectileTypeIndex];
+        }
+
+        LastAccessedRenderer.UpdateBufferData(ProjectileTypes[LastAccessedProjectileTypeIndex].BufferIndex, data);
+        ProjectileTypes[LastAccessedProjectileTypeIndex].BufferIndex++;
     }
     
     public void Update()

--- a/Assets/Scripts/ProjectileManager.cs
+++ b/Assets/Scripts/ProjectileManager.cs
@@ -129,8 +129,8 @@ public class ProjectileManager : MonoBehaviour
             LastAccessedRenderer = IndirectRenderers[LastAccessedProjectileTypeIndex];
         }
 
-        LastAccessedRenderer.UpdateBufferData(ProjectileTypes[LastAccessedProjectileTypeIndex].BufferIndex, data);
-        ProjectileTypes[LastAccessedProjectileTypeIndex].BufferIndex++;
+        LastAccessedRenderer.UpdateBufferData(projectileType.BufferIndex, data);
+        projectileType.BufferIndex++;
     }
     
     public void Update()


### PR DESCRIPTION
I've made optimizations on some low bearing fruit:

- raycast call was corrected to use contact filter
- bouncing calculation was fixed (for single bounce per frame, multiple bounces from a single bullet  in a single frame won't work)
- ProjectileManager.Instance call was cached cause the null check hit the performance hard
- Dictionary and List lookups in ProjectileManager were optimized (cached the last looked up type)

This gave me about a 40% performance improvement on my machine, the biggest factor being the raycast call. In the initial attempt I made there were further optimizations done by not calling find on all emitters each frame. I wasn't satisfied with the solution proposed so I left it out here.